### PR TITLE
Use logback config file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline{
 					def releaseVersion = utils.getReleaseVersion()
 					sh "mkdir -p ${env.OUTPUT_FOLDER}"
 					withCredentials([usernamePassword(credentialsId: 'neo4jUsernamePassword', passwordVariable: 'pass', usernameVariable: 'user')]){
-						sh "java -jar target/fireworks-jar-with-dependencies.jar --user $user --password $pass --folder ./config --output ./${env.OUTPUT_FOLDER}"
+						sh "java -Dlogback.configurationFile=/path/to/config.xml myProject.jar -jar target/fireworks-jar-with-dependencies.jar --user $user --password $pass --folder ./config --output ./${env.OUTPUT_FOLDER}"
 						// Create archive that will be stored on S3.
 						sh "tar -zcf fireworks-v${releaseVersion}.tgz ${env.OUTPUT_FOLDER}/"
 					}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline{
 					def releaseVersion = utils.getReleaseVersion()
 					sh "mkdir -p ${env.OUTPUT_FOLDER}"
 					withCredentials([usernamePassword(credentialsId: 'neo4jUsernamePassword', passwordVariable: 'pass', usernameVariable: 'user')]){
-						sh "java -Dlogback.configurationFile=/path/to/config.xml myProject.jar -jar target/fireworks-jar-with-dependencies.jar --user $user --password $pass --folder ./config --output ./${env.OUTPUT_FOLDER}"
+						sh "java -Dlogback.configurationFile=src/main/resources/logback.xml -jar target/fireworks-jar-with-dependencies.jar --user $user --password $pass --folder ./config --output ./${env.OUTPUT_FOLDER}"
 						// Create archive that will be stored on S3.
 						sh "tar -zcf fireworks-v${releaseVersion}.tgz ${env.OUTPUT_FOLDER}/"
 					}


### PR DESCRIPTION
It looks like Justin had tested this successfully (https://release.reactome.org/jenkins/job/Releases/job/75/job/File-Generation/job/FireworksLayout/configure) but never committed the change.

This change will suppress DEBUG and TRACE output from some 3rd-party libraries, such as the Neo4j and Apache HTTP.